### PR TITLE
fix ImportNamespace conversion

### DIFF
--- a/src/to-shift.js
+++ b/src/to-shift.js
@@ -601,13 +601,13 @@ function convertExportDefaultDeclaration(node) {
 function convertImportDeclaration(node) {
   let hasDefaultSpecifier = node.specifiers.some(s => s.type === "ImportDefaultSpecifier"),
       hasNamespaceSpecifier = node.specifiers.some(s => s.type === "ImportNamespaceSpecifier"),
-      defaultBinding = hasDefaultSpecifier ? toBinding(node.specifiers[0]): null;
+      firstBinding = toBinding(node.specifiers[0]);
 
   if(hasNamespaceSpecifier) {
     return new Shift.ImportNamespace({
       moduleSpecifier: node.source.value,
-      namespaceBinding: toBinding(node.specifiers[1]),
-      defaultBinding
+      namespaceBinding: hasDefaultSpecifier ? toBinding(node.specifiers[1]) : firstBinding,
+      defaultBinding: hasDefaultSpecifier ? firstBinding : null
     });
   }
 
@@ -616,7 +616,7 @@ function convertImportDeclaration(node) {
   return new Shift.Import({
     moduleSpecifier: node.source.value,
     namedImports,
-    defaultBinding
+    defaultBinding: firstBinding
   });
 }
 

--- a/src/to-spidermonkey.js
+++ b/src/to-spidermonkey.js
@@ -862,19 +862,23 @@ function convertImport(node) {
 }
 
 function convertImportNamespace(node) {
+  let specifiers = [{
+    type: "ImportNamespaceSpecifier",
+    local: convert(node.namespaceBinding)
+  }];
+  if(node.defaultBinding != null) {
+    specifiers.unshift({
+      type: "ImportDefaultSpecifier",
+      local: convert(node.defaultBinding)
+    });
+  }
   return {
     type: "ImportDeclaration",
     source: {
       type: "Literal",
       value: node.moduleSpecifier
     },
-    specifiers: [{
-      type: "ImportDefaultSpecifier",
-      local: convert(node.defaultBinding)
-    }, {
-      type: "ImportNamespaceSpecifier",
-      local: convert(node.namespaceBinding)
-    }]
+    specifiers
   };
 }
 

--- a/test/simple.js
+++ b/test/simple.js
@@ -139,6 +139,7 @@ suite("simple", function () {
     roundTrip("Import", `import "a"`);
     roundTrip("ImportNamespace", `import a, * as b from "a"`);
     roundTrip("ImportSpecifier", `import a, {b as c} from "a"`);
+    roundTrip("ImportNamespace", `import * as _ from "a"`);
     roundTrip("Method", `({[6+3]() {}})`);
     roundTrip("Method", `({*"a"() {}})`);
     roundTrip("Getter", `({get 'b'() {}})`);


### PR DESCRIPTION
I was assigning the value that should have gone to `node.defaultBinding` to `node.namespaceBinding` and not nulling out `node.defaultBinding` in `toShift`.

In `toSpiderMonkey` I was adding an `ImportDefaultSpecifier` when there was no default binding.

A test has been added and the case has been fixed.
