### PR TITLE
fix to import specifiers and break statements

### DIFF
--- a/src/to-spidermonkey.js
+++ b/src/to-spidermonkey.js
@@ -300,7 +300,7 @@ function convertBlockStatement(node) {
 function convertBreakStatement(node) {
   return {
     type: "BreakStatement",
-    label: createIdentifier(node.label)
+    label: node.label ? createIdentifier(node.label) : null
   };
 }
 

--- a/test/simple.js
+++ b/test/simple.js
@@ -138,8 +138,10 @@ suite("simple", function () {
     roundTrip("Module", `export function f(){};0`);
     roundTrip("Import", `import "a"`);
     roundTrip("ImportNamespace", `import a, * as b from "a"`);
-    roundTrip("ImportSpecifier", `import a, {b as c} from "a"`);
     roundTrip("ImportNamespace", `import * as _ from "a"`);
+    roundTrip("ImportSpecifier", `import a, {b as c} from "a"`);
+    roundTrip("ImportSpecifier", `import {b} from "a"`);
+    roundTrip("ImportSpecifier", `import {} from "a"`);
     roundTrip("Method", `({[6+3]() {}})`);
     roundTrip("Method", `({*"a"() {}})`);
     roundTrip("Getter", `({get 'b'() {}})`);


### PR DESCRIPTION
I'm not sure if you should merge this yet. I keep finding bugs as I'm working on integrating my babel branch w/ sweet.js (https://github.com/mozilla/sweet.js/issues/515).

I could work on https://github.com/shapesecurity/shift-spidermonkey-converter-js/issues/11 and see about adding some more test cases to `simple.js` pulling from `everything.js`.
