### PR TITLE
Change to a class-based implementation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,7 @@
-import toSpiderMonkey from "./to-spidermonkey.js";
-import toShift from "./to-shift.js";
+import SpiderMonkeyConverter from "./to-spidermonkey.js";
+import ShiftConverter from "./to-shift.js";
 
-export {toSpiderMonkey, toShift}
+const toSpiderMonkey = SpiderMonkeyConverter.convert.bind(SpiderMonkeyConverter);
+const toShift = ShiftConverter.convert.bind(ShiftConverter);
+
+export { SpiderMonkeyConverter, toSpiderMonkey, ShiftConverter, toShift };

--- a/src/to-shift.js
+++ b/src/to-shift.js
@@ -18,689 +18,551 @@ import * as Shift from "shift-ast";
 
 // convert SpiderMonkey AST format to Shift AST format
 
-export default function convert(node) {
-  if (node == null) {
-    return null;
-  }
-
-  return Convert[node.type](node);
-}
-
-function toBinding(node) {
-  if(node == null) return null;
-  switch(node.type) {
-    case "Identifier": return new Shift.BindingIdentifier({ name: node.name });
-    case "Property": if(node.shorthand) {
-      return new Shift.BindingPropertyIdentifier({
-        binding: toBinding(node.key),
-        init: toExpression(node.value.right)
-      });
-    } else {
-      return new Shift.BindingPropertyProperty({
-        name: toPropertyName(node.key, node.computed),
-        binding: toBinding(node.value)
-      });
-    }
-    default: return convert(node);
-  }
-}
-
-function convertAssignmentExpression(node) {
-  let binding = toBinding(node.left),
-      expression = toExpression(node.right),
+const ShiftConverter = {
+  convertAssignmentExpression(node) {
+    let binding = this.toBinding(node.left),
+      expression = this.toExpression(node.right),
       operator = node.operator;
-  if(operator === "=") return new Shift.AssignmentExpression({ binding, expression });
-  else return new Shift.CompoundAssignmentExpression({ binding, expression, operator });
-}
-
-function convertArrayExpression(node) {
-  return new Shift.ArrayExpression({ elements: node.elements.map(convert) });
-}
-
-function convertBinaryExpression(node) {
-  return new Shift.BinaryExpression({
-    operator: node.operator,
-    left: convert(node.left),
-    right: convert(node.right)
-  });
-}
-
-function convertBlock(node) {
-  return new Shift.Block({ statements: node.body.map(convert) });
-}
-
-function convertBlockStatement(node) {
-  return new Shift.BlockStatement({ block: convertBlock(node) });
-}
-
-function convertBreakStatement(node) {
-  return new Shift.BreakStatement({ label: node.label ? node.label.name : null });
-}
-
-function toExpression(node) {
-  if(node == null) return null;
-  switch(node.type) {
-    case "Literal": return convertLiteral(node);
-    case "Identifier": return new Shift.IdentifierExpression({ name: node.name });
-    case "MetaProperty": return new Shift.NewTargetExpression();
-    case "TemplateLiteral": return convertTemplateLiteral(node);
-    default: return convert(node);
-  }
-}
-
-function toArgument(node) {
-  if(node.type === "SpreadElement") {
-    return convertSpreadElement(node);
-  }
-  return toExpression(node);
-}
-
-function convertCallExpression(node) {
-  let callee = node.callee.type === "Super" ?
-      convertSuper(node.callee) :
-      toExpression(node.callee);
-  return new Shift.CallExpression({ callee, arguments: node.arguments.map(toArgument) });
-}
-
-function convertCatchClause(node) {
-  return new Shift.CatchClause({
-    binding: toBinding(node.param),
-    body: convertBlock(node.body)
-  });
-}
-
-function convertConditionalExpression(node) {
-  return new Shift.ConditionalExpression({
-    test: toExpression(node.test),
-    consequent: toExpression(node.consequent),
-    alternate: toExpression(node.alternate)
-  });
-}
-
-function convertContinueStatement(node) {
-  return new Shift.ContinueStatement({ label: node.label ? node.label.name : null });
-}
-
-function convertDebuggerStatement() {
-  return new Shift.DebuggerStatement();
-}
-
-function convertDoWhileStatement(node) {
-  return new Shift.DoWhileStatement({
-    body: convert(node.body),
-    test: convert(node.test)
-  });
-}
-
-function convertEmptyStatement() {
-  return new Shift.EmptyStatement();
-}
-
-function convertExpressionStatement(node) {
-  return new Shift.ExpressionStatement({ expression: toExpression(node.expression) });
-}
-
-function convertForStatement(node) {
-  let init = (node.init != null && node.init.type === "VariableDeclaration") ?
-      convertVariableDeclaration(node.init, true) :
-      toExpression(node.init);
-  return new Shift.ForStatement({
-    init,
-    test: toExpression(node.test),
-    update: toExpression(node.update),
-    body: convert(node.body)
-  });
-}
-
-function convertForInStatement(node) {
-  let left = node.left.type === "VariableDeclaration" ?
-      convertVariableDeclaration(node.left, true) :
-      toBinding(node.left);
-  return new Shift.ForInStatement({
-    left,
-    right: toExpression(node.right),
-    body: convert(node.body)
-  });
-}
-
-function convertForOfStatement(node) {
-  let left = node.left.type === "VariableDeclaration" ?
-      convertVariableDeclaration(node.left, true) :
-      toBinding(node.left);
-  return new Shift.ForOfStatement({
-    left,
-    right: toExpression(node.right),
-    body: convert(node.body)
-  });
-}
-
-function convertFunctionDeclaration(node) {
-  return new Shift.FunctionDeclaration({
-    isGenerator: node.generator,
-    name: toBinding(node.id),
-    params: new Shift.FormalParameters(convertFunctionParams(node)),
-    body: convertStatementsToFunctionBody(node.body.body)
-  });
-}
-
-function convertFunctionExpression(node) {
-  return new Shift.FunctionExpression({
-    isGenerator: node.generator,
-    name: toBinding(node.id),
-    params: new Shift.FormalParameters(convertFunctionParams(node)),
-    body: convertStatementsToFunctionBody(node.body.body)
-  });
-}
-
-function convertIfStatement(node) {
-  return new Shift.IfStatement({
-    test: toExpression(node.test),
-    consequent: convert(node.consequent),
-    alternate: convert(node.alternate)
-  });
-}
-
-function convertLabeledStatement(node) {
-  return new Shift.LabeledStatement({
-    label: node.label.name,
-    body: convert(node.body)
-  });
-}
-
-function convertLiteral(node) {
-  switch (typeof node.value) {
-    case "number":
-      if (node.value === 1 / 0) {
-        return new Shift.LiteralInfinityExpression();
-      }
-      return new Shift.LiteralNumericExpression(node);
-    case "string":
-      return new Shift.LiteralStringExpression(node);
-    case "boolean":
-      return new Shift.LiteralBooleanExpression(node);
-    default:
-      if (node.value === null)
-        return new Shift.LiteralNullExpression();
-      else
-        return new Shift.LiteralRegExpExpression(node.regex);
-  }
-}
-
-function convertMemberExpression(node) {
-  let obj = node.object.type === "Super" ?
-      convertSuper(node.object) :
-      toExpression(node.object);
-
-  if (node.computed) {
-    return new Shift.ComputedMemberExpression({
-      object: obj,
-      expression: toExpression(node.property)
+    if (operator === "=") return new Shift.AssignmentExpression({ binding, expression });
+    else return new Shift.CompoundAssignmentExpression({ binding, expression, operator });
+  },
+  convertAssignmentPattern(node) {
+    return new Shift.BindingWithDefault({
+      binding: this.toBinding(node.left),
+      init: this.convert(node.right)
     });
-  } else {
-    return new Shift.StaticMemberExpression({
-      object: obj,
-      property: node.property.name
+  },
+  convertArrayExpression(node) {
+    return new Shift.ArrayExpression({ elements: node.elements.map(this.convert.bind(this)) });
+  },
+  convertArrayPattern(node) {
+    let [elements, restElement] = this.convertElements(node.elements);
+    return new Shift.ArrayBinding({ elements, restElement });
+  },
+  convertArrowFunctionExpression(node) {
+    return new Shift.ArrowExpression({
+      params: new Shift.FormalParameters(this.convertFunctionParams(node)),
+      body: node.expression ? this.convert(node.body) : this.convertStatementsToFunctionBody(node.body.body)
     });
-  }
-}
-
-function convertNewExpression(node) {
-  return new Shift.NewExpression({
-    callee: toArgument(node.callee),
-    arguments: node.arguments.map(toArgument)
-  });
-}
-
-function convertObjectExpression(node) {
-  return new Shift.ObjectExpression({ properties: node.properties.map(convert) });
-}
-
-function convertDirective(node) {
-  node = node.expression;
-  var value = node.value;
-  return new Shift.Directive({rawValue: value});
-}
-
-function convertStatementsToFunctionBody(stmts) {
-  for (var i = 0; i < stmts.length; i++) {
-    if (!(stmts[i].type === "ExpressionStatement" && stmts[i].expression.type === "Literal" && typeof stmts[i].expression.value === "string")) {
-      break;
+  },
+  convertBlockStatement(node) {
+    return new Shift.BlockStatement({ block: this.convertBlock(node) });
+  },
+  convertBinaryExpression(node) {
+    return new Shift.BinaryExpression({
+      operator: node.operator,
+      left: this.convert(node.left),
+      right: this.convert(node.right)
+    });
+  },
+  convertBreakStatement(node) {
+    return new Shift.BreakStatement({ label: node.label ? node.label.name : null });
+  },
+  convertCallExpression(node) {
+    let callee = node.callee.type === "Super" ?
+      this.convertSuper(node.callee) :
+      this.toExpression(node.callee);
+    return new Shift.CallExpression({ callee, arguments: node.arguments.map(this.toArgument.bind(this)) });
+  },
+  convertCatchClause(node) {
+    return new Shift.CatchClause({
+      binding: this.toBinding(node.param),
+      body: this.convertBlock(node.body)
+    });
+  },
+  convertClassDeclaration(node) {
+    return new Shift.ClassDeclaration({
+      name: this.toBinding(node.id),
+      super: this.toExpression(node.superClass),
+      elements: this.convert(node.body)
+    });
+  },
+  convertClassExpression(node) {
+    let {name, super: spr, elements} = this.convertClassDeclaration(node);
+    return new Shift.ClassExpression({ name, super: spr, elements });
+  },
+  convertClassBody(node) {
+    return node.body.map(this.convert.bind(this));
+  },
+  convertConditionalExpression(node) {
+    return new Shift.ConditionalExpression({
+      test: this.toExpression(node.test),
+      consequent: this.toExpression(node.consequent),
+      alternate: this.toExpression(node.alternate)
+    });
+  },
+  convertContinueStatement(node) {
+    return new Shift.ContinueStatement({ label: node.label ? node.label.name : null });
+  },
+  convertDoWhileStatement(node) {
+    return new Shift.DoWhileStatement({
+      body: this.convert(node.body),
+      test: this.convert(node.test)
+    });
+  },
+  convertDebuggerStatement() {
+    return new Shift.DebuggerStatement();
+  },
+  convertEmptyStatement() {
+    return new Shift.EmptyStatement();
+  },
+  convertExportAllDeclaration(node) {
+    return new Shift.ExportAllFrom({ moduleSpecifier: node.source.value });
+  },
+  convertExportDefaultDeclaration(node) {
+    return new Shift.ExportDefault({ body: this.convert(node.declaration) });
+  },
+  convertExportNamedDeclaration(node) {
+    if (node.declaration != null) {
+      return new Shift.Export({
+        kind: node.kind,
+        declaration: (node.declaration.type === "VariableDeclaration") ?
+          this.convertVariableDeclaration(node.declaration, true) :
+          this.convert(node.declaration)
+      });
     }
-  }
-  return new Shift.FunctionBody({
-    directives: stmts.slice(0, i).map(convertDirective),
-    statements: stmts.slice(i).map(convert)
-  });
-}
 
-function convertProgram(node) {
-  let directives = node.directives ? node.directives.map(convertDirective) : [],
-      statements = node.body.map(convert);
-
-  if(node.sourceType === "module") {
-    return new Shift.Module({ directives, items: statements });
-  }
-  return new Shift.Script({ directives, statements });
-}
-
-function toPropertyName(node, computed) {
-  if(computed) {
-    return new Shift.ComputedPropertyName({ expression: toExpression(node)});
-  } else {
-    return new Shift.StaticPropertyName({
-      value: (node.type === "Identifier") ? node.name : node.value.toString()
+    return new Shift.ExportFrom({
+      moduleSpecifier: node.source != null ? node.source.value : null,
+      namedExports: node.specifiers.map(this.convert.bind(this))
     });
-  }
-}
+  },
+  convertExportSpecifier(node) {
+    return new Shift.ExportSpecifier({
+      exportedName: node.exported.name,
+      name: node.local.name !== node.exported.name ? node.local.name : null
+    });
+  },
+  convertExpressionStatement(node) {
+    return new Shift.ExpressionStatement({ expression: this.toExpression(node.expression) });
+  },
+  convertForStatement(node) {
+    let init = (node.init != null && node.init.type === "VariableDeclaration") ?
+      this.convertVariableDeclaration(node.init, true) :
+      this.toExpression(node.init);
+    return new Shift.ForStatement({
+      init,
+      test: this.toExpression(node.test),
+      update: this.toExpression(node.update),
+      body: this.convert(node.body)
+    });
+  },
+  convertForOfStatement(node) {
+    let left = node.left.type === "VariableDeclaration" ?
+      this.convertVariableDeclaration(node.left, true) :
+      this.toBinding(node.left);
+    return new Shift.ForOfStatement({
+      left,
+      right: this.toExpression(node.right),
+      body: this.convert(node.body)
+    });
+  },
+  convertForInStatement(node) {
+    let left = node.left.type === "VariableDeclaration" ?
+      this.convertVariableDeclaration(node.left, true) :
+      this.toBinding(node.left);
+    return new Shift.ForInStatement({
+      left,
+      right: this.toExpression(node.right),
+      body: this.convert(node.body)
+    });
+  },
+  convertFunctionDeclaration(node) {
+    return new Shift.FunctionDeclaration({
+      isGenerator: node.generator,
+      name: this.toBinding(node.id),
+      params: new Shift.FormalParameters(this.convertFunctionParams(node)),
+      body: this.convertStatementsToFunctionBody(node.body.body)
+    });
+  },
+  convertFunctionExpression(node) {
+    return new Shift.FunctionExpression({
+      isGenerator: node.generator,
+      name: this.toBinding(node.id),
+      params: new Shift.FormalParameters(this.convertFunctionParams(node)),
+      body: this.convertStatementsToFunctionBody(node.body.body)
+    });
+  },
+  convertIfStatement(node) {
+    return new Shift.IfStatement({
+      test: this.toExpression(node.test),
+      consequent: this.convert(node.consequent),
+      alternate: this.convert(node.alternate)
+    });
+  },
+  convertImportDeclaration(node) {
+    let hasDefaultSpecifier = node.specifiers.some(s => s.type === "ImportDefaultSpecifier");
+    if (node.specifiers.some(s => s.type === "ImportNamespaceSpecifier"))
+      return this.toImportNamespace(node, hasDefaultSpecifier);
 
-function toInitProperty(node) {
-  let name = toPropertyName(node.key, node.computed);
-  if(node.shorthand) {
-    return new Shift.ShorthandProperty({ name: node.key.name });
-  }
-  return new Shift.DataProperty({ name, expression: toExpression(node.value)});
-}
+    let namedImports = node.specifiers.map(this.convert.bind(this));
+    if (hasDefaultSpecifier) namedImports.shift();
+    return new Shift.Import({
+      moduleSpecifier: node.source.value,
+      namedImports,
+      defaultBinding: hasDefaultSpecifier ? this.toBinding(node.specifiers[0]) : null
+    });
+  },
+  convertImportDefaultSpecifier(node) {
+    return this.toBinding(node.local);
+  },
+  convertImportNamespaceSpecifier(node) {
+    return this.toBinding(node.local);
+  },
+  convertImportSpecifier(node) {
+    return new Shift.ImportSpecifier({ name: node.imported.name, binding: this.toBinding(node.local) });
+  },
+  convertLiteral(node) {
+    switch (typeof node.value) {
+      case "number":
+        if (node.value === 1 / 0) {
+          return new Shift.LiteralInfinityExpression();
+        }
+        return new Shift.LiteralNumericExpression(node);
+      case "string":
+        return new Shift.LiteralStringExpression(node);
+      case "boolean":
+        return new Shift.LiteralBooleanExpression(node);
+      default:
+        if (node.value === null)
+          return new Shift.LiteralNullExpression();
+        else
+          return new Shift.LiteralRegExpExpression(node.regex);
+    }
+  },
+  convertLabeledStatement(node) {
+    return new Shift.LabeledStatement({
+      label: node.label.name,
+      body: this.convert(node.body)
+    });
+  },
+  convertLogicalExpression(node) {
+    return this.convertBinaryExpression(node);
+  },
+  convertMemberExpression(node) {
+    let obj = node.object.type === "Super" ?
+      this.convertSuper(node.object) :
+      this.toExpression(node.object);
 
-function toMethod(node) {
-  return new Shift.Method({
-    isGenerator: node.value.generator,
-    name: toPropertyName(node.key, node.computed),
-    body: convertStatementsToFunctionBody(node.value.body.body),
-    params: new Shift.FormalParameters(convertFunctionParams(node.value))
-  });
-}
-
-function toGetter(node) {
-  return new Shift.Getter({
-    name: toPropertyName(node.key, node.computed),
-    body: convertStatementsToFunctionBody(node.value.body.body)
-  });
-}
-
-function toSetter(node) {
-  let params = convertFunctionParams(node.value);
-  return new Shift.Setter({
-    name: toPropertyName(node.key, node.computed),
-    body: convertStatementsToFunctionBody(node.value.body.body),
-    param: params.items[0] || params.rest
-  });
-}
-
-function convertProperty(node) {
-  switch (node.kind) {
-    case "init": if(node.method) {
-      return toMethod(node);
+    if (node.computed) {
+      return new Shift.ComputedMemberExpression({
+        object: obj,
+        expression: this.toExpression(node.property)
+      });
     } else {
-      return toInitProperty(node);
+      return new Shift.StaticMemberExpression({
+        object: obj,
+        property: node.property.name
+      });
     }
-    case "get": return toGetter(node);
-    case "set": return toSetter(node);
-    default: throw Error(`Unknown kind of Property: ${node.kind}`);
-  }
-}
-
-function convertReturnStatement(node) {
-  return new Shift.ReturnStatement({ expression: toExpression(node.argument) });
-}
-
-function convertSequenceExpression(node) {
-  var expr = toExpression(node.expressions[0]);
-  for (var i = 1; i < node.expressions.length; i++) {
-    expr = new Shift.BinaryExpression({
-      operator: ",",
-      left: expr,
-      right: toExpression(node.expressions[i])
+  },
+  convertMetaProperty(node) {
+    if (node.meta === "new" && node.property === "target") {
+      return new Shift.NewTargetExpression();
+    }
+    return null;
+  },
+  convertMethodDefinition(node) {
+    return new Shift.ClassElement({ isStatic: node.static, method: this.toMethod(node) });
+  },
+  convertNewExpression(node) {
+    return new Shift.NewExpression({
+      callee: this.toArgument(node.callee),
+      arguments: node.arguments.map(this.toArgument.bind(this))
     });
-  }
-  return expr;
-}
+  },
+  convertObjectExpression(node) {
+    return new Shift.ObjectExpression({ properties: node.properties.map(this.convert.bind(this)) });
+  },
+  convertObjectPattern(node) {
+    return new Shift.ObjectBinding({ properties: node.properties.map(this.toBinding.bind(this)) });
+  },
+  convertProgram(node) {
+    let directives = node.directives ? node.directives.map(this.convertDirective.bind(this)) : [],
+      statements = node.body.map(this.convert.bind(this));
 
-function convertSwitchCase(node) {
-  if (node.test) {
-    return new Shift.SwitchCase({
-      test: convert(node.test),
-      consequent: node.consequent.map(convert)
+    if (node.sourceType === "module") {
+      return new Shift.Module({ directives, items: statements });
+    }
+    return new Shift.Script({ directives, statements });
+  },
+  convertProperty(node) {
+    switch (node.kind) {
+      case "init": if (node.method) {
+        return this.toMethod(node);
+      } else {
+        return this.toInitProperty(node);
+      }
+      case "get": return this.toGetter(node);
+      case "set": return this.toSetter(node);
+      default: throw Error(`Unknown kind of Property: ${node.kind}`);
+    }
+  },
+  convertRestElement(node) {
+    return this.toBinding(node.argument);
+  },
+  convertReturnStatement(node) {
+    return new Shift.ReturnStatement({ expression: this.toExpression(node.argument) });
+  },
+  convertSequenceExpression(node) {
+    var expr = this.toExpression(node.expressions[0]);
+    for (var i = 1; i < node.expressions.length; i++) {
+      expr = new Shift.BinaryExpression({
+        operator: ",",
+        left: expr,
+        right: this.toExpression(node.expressions[i])
+      });
+    }
+    return expr;
+  },
+  convertSpreadElement(node) {
+    return new Shift.SpreadElement({ expression: this.toExpression(node.argument) });
+  },
+  convertSuper() {
+    return new Shift.Super();
+  },
+  convertSwitchCase(node) {
+    if (node.test) {
+      return new Shift.SwitchCase({
+        test: this.convert(node.test),
+        consequent: node.consequent.map(this.convert.bind(this))
+      });
+    }
+    return new Shift.SwitchDefault({ consequent: node.consequent.map(this.convert.bind(this)) });
+  },
+  convertSwitchStatement(node) {
+    if (!node.cases.every((c) => c.test != null)) {
+      var scs = node.cases.map(this.convertSwitchCase.bind(this));
+      for (var i = 0; i < scs.length; i++) {
+        if (scs[i].type === "SwitchDefault") {
+          break;
+        }
+      }
+      return new Shift.SwitchStatementWithDefault({
+        discriminant: this.toExpression(node.discriminant),
+        preDefaultCases: scs.slice(0, i),
+        defaultCase: scs[i],
+        postDefaultCases: scs.slice(i + 1)
+      });
+    } else {
+      return new Shift.SwitchStatement({
+        discriminant: this.toExpression(node.discriminant),
+        cases: node.cases.map(this.convertSwitchCase.bind(this))
+      });
+    }
+  },
+  convertTaggedTemplateExpression(node) {
+    let elts = [];
+    node.quasi.quasis.forEach((e, i) => {
+      elts.push(this.convertTemplateElement(e));
+      if (i < node.quasi.expressions.length) elts.push(this.toExpression(node.quasi.expressions[i]));
     });
-  }
-  return new Shift.SwitchDefault({ consequent: node.consequent.map(convert) });
-}
+    return new Shift.TemplateExpression({
+      tag: this.toExpression(node.tag),
+      elements: elts
+    });
+  },
+  convertTemplateElement(node) {
+    return new Shift.TemplateElement({ rawValue: node.value.raw });
+  },
+  convertTemplateLiteral(node, tag) {
+    let elts = [];
+    node.quasis.forEach((e, i) => {
+      elts.push(this.convertTemplateElement(e));
+      if (i < node.expressions.length) elts.push(this.toExpression(node.expressions[i]));
+    });
+    return new Shift.TemplateExpression({
+      tag: tag != null ? this.convert(tag) : null,
+      elements: elts
+    });
+  },
+  convertThisExpression() {
+    return new Shift.ThisExpression();
+  },
+  convertThrowStatement(node) {
+    return new Shift.ThrowStatement({ expression: this.toExpression(node.argument) });
+  },
+  convertTryStatement(node) {
+    if (node.finalizer != null) {
+      return new Shift.TryFinallyStatement({
+        body: this.convertBlock(node.block),
+        catchClause: this.convertCatchClause(node.handler),
+        finalizer: this.convertBlock(node.finalizer)
+      });
+    } else {
+      return new Shift.TryCatchStatement({
+        body: this.convertBlock(node.block),
+        catchClause: this.convertCatchClause(node.handler),
+        handlers: node.handlers.map(this.convert.bind(this))
+      });
+    }
+  },
+  convertUnaryExpression(node) {
+    return new Shift.UnaryExpression({
+      operator: node.operator,
+      operand: this.toExpression(node.argument)
+    });
+  },
+  convertUpdateExpression(node) {
+    return new Shift.UpdateExpression({
+      isPrefix: node.prefix,
+      operator: node.operator,
+      operand: this.toBinding(node.argument)
+    });
+  },
+  convertVariableDeclaration(node, isDeclaration) {
+    let declaration = new Shift.VariableDeclaration({
+      kind: node.kind,
+      declarators: node.declarations.map(this.convertVariableDeclarator.bind(this))
+    });
+    if (isDeclaration) return declaration;
+    return new Shift.VariableDeclarationStatement({ declaration });
+  },
+  convertVariableDeclarator(node) {
+    return new Shift.VariableDeclarator({
+      binding: this.toBinding(node.id),
+      init: this.convert(node.init)
+    });
+  },
+  convertWhileStatement(node) {
+    return new Shift.WhileStatement({ test: this.convert(node.test), body: this.convert(node.body) });
+  },
+  convertWithStatement(node) {
+    return new Shift.WithStatement({ object: this.convert(node.object), body: this.convert(node.body) });
+  },
+  convertYieldExpression(node) {
+    if (node.delegate) return new Shift.YieldGeneratorExpression({ expression: this.toExpression(node.argument) });
+    return new Shift.YieldExpression({ expression: this.toExpression(node.argument) });
+  },
 
-function convertSwitchStatement(node) {
-  if (!node.cases.every((c) => c.test != null )) {
-    var scs = node.cases.map(convertSwitchCase);
-    for (var i = 0; i < scs.length; i++) {
-      if (scs[i].type === "SwitchDefault") {
+  // auxiliary methods
+  convert(node) {
+    if (node == null) {
+      return null;
+    }
+    return this[`convert${node.type}`](node);
+  },
+  toBinding(node) {
+    if (node == null) return null;
+    switch (node.type) {
+      case "Identifier": return new Shift.BindingIdentifier({ name: node.name });
+      case "Property": if (node.shorthand) {
+        return new Shift.BindingPropertyIdentifier({
+          binding: this.toBinding(node.key),
+          init: this.toExpression(node.value.right)
+        });
+      } else {
+        return new Shift.BindingPropertyProperty({
+          name: this.toPropertyName(node.key, node.computed),
+          binding: this.toBinding(node.value)
+        });
+      }
+      default: return this.convert(node);
+    }
+  },
+  convertBlock(node) {
+    return new Shift.Block({ statements: node.body.map(this.convert.bind(this)) });
+  },
+  toExpression(node) {
+    if (node == null) return null;
+    switch (node.type) {
+      case "Literal": return this.convertLiteral(node);
+      case "Identifier": return new Shift.IdentifierExpression({ name: node.name });
+      case "MetaProperty": return new Shift.NewTargetExpression();
+      case "TemplateLiteral": return this.convertTemplateLiteral(node);
+      default: return this.convert(node);
+    }
+  },
+  toArgument(node) {
+    if (node.type === "SpreadElement") {
+      return this.convertSpreadElement(node);
+    }
+    return this.toExpression(node);
+  },
+  convertDirective(node) {
+    node = node.expression;
+    return new Shift.Directive({ rawValue: node.value });
+  },
+  convertStatementsToFunctionBody(stmts) {
+    for (var i = 0; i < stmts.length; i++) {
+      if (!(stmts[i].type === "ExpressionStatement" && stmts[i].expression.type === "Literal" && typeof stmts[i].expression.value === "string")) {
         break;
       }
     }
-    return new Shift.SwitchStatementWithDefault({
-      discriminant: toExpression(node.discriminant),
-      preDefaultCases: scs.slice(0, i),
-      defaultCase: scs[i],
-      postDefaultCases: scs.slice(i + 1)
+    return new Shift.FunctionBody({
+      directives: stmts.slice(0, i).map(this.convertDirective.bind(this)),
+      statements: stmts.slice(i).map(this.convert.bind(this))
     });
-  } else {
-    return new Shift.SwitchStatement({
-      discriminant: toExpression(node.discriminant),
-      cases: node.cases.map(convertSwitchCase)
+  },
+  toPropertyName(node, computed) {
+    if (computed) {
+      return new Shift.ComputedPropertyName({ expression: this.toExpression(node) });
+    } else {
+      return new Shift.StaticPropertyName({
+        value: (node.type === "Identifier") ? node.name : node.value.toString()
+      });
+    }
+  },
+  toInitProperty(node) {
+    let name = this.toPropertyName(node.key, node.computed);
+    if (node.shorthand) {
+      return new Shift.ShorthandProperty({ name: node.key.name });
+    }
+    return new Shift.DataProperty({ name, expression: this.toExpression(node.value) });
+  },
+  toMethod(node) {
+    return new Shift.Method({
+      isGenerator: node.value.generator,
+      name: this.toPropertyName(node.key, node.computed),
+      body: this.convertStatementsToFunctionBody(node.value.body.body),
+      params: new Shift.FormalParameters(this.convertFunctionParams(node.value))
     });
-  }
-}
-
-function convertThisExpression() {
-  return new Shift.ThisExpression();
-}
-
-function convertThrowStatement(node) {
-  return new Shift.ThrowStatement({ expression: toExpression(node.argument) });
-}
-
-function convertTryStatement(node) {
-  if (node.finalizer != null) {
-    return new Shift.TryFinallyStatement({
-      body: convertBlock(node.block),
-      catchClause: convertCatchClause(node.handler),
-      finalizer: convertBlock(node.finalizer)
+  },
+  toGetter(node) {
+    return new Shift.Getter({
+      name: this.toPropertyName(node.key, node.computed),
+      body: this.convertStatementsToFunctionBody(node.value.body.body)
     });
-  } else {
-    return new Shift.TryCatchStatement({
-      body: convertBlock(node.block),
-      catchClause: convertCatchClause(node.handler),
-      handlers: node.handlers.map(convert)
+  },
+  toSetter(node) {
+    let params = this.convertFunctionParams(node.value);
+    return new Shift.Setter({
+      name: this.toPropertyName(node.key, node.computed),
+      body: this.convertStatementsToFunctionBody(node.value.body.body),
+      param: params.items[0] || params.rest
     });
-  }
-}
-
-function convertUpdateExpression(node) {
-  return new Shift.UpdateExpression({
-    isPrefix: node.prefix,
-    operator: node.operator,
-    operand: toBinding(node.argument)
-  });
-}
-
-function convertUnaryExpression(node) {
-  return new Shift.UnaryExpression({
-    operator: node.operator,
-    operand: toExpression(node.argument)
-  });
-}
-
-function convertVariableDeclaration(node, isDeclaration) {
-  let declaration = new Shift.VariableDeclaration({
-    kind: node.kind,
-    declarators: node.declarations.map(convertVariableDeclarator)
-  });
-  if(isDeclaration) return declaration;
-  return new Shift.VariableDeclarationStatement({ declaration });
-}
-
-function convertVariableDeclarator(node) {
-  return new Shift.VariableDeclarator({
-    binding: toBinding(node.id),
-    init: convert(node.init)
-  });
-}
-
-function convertWhileStatement(node) {
-  return new Shift.WhileStatement({ test: convert(node.test), body: convert(node.body) });
-}
-
-function convertWithStatement(node) {
-  return new Shift.WithStatement({ object: convert(node.object), body: convert(node.body) });
-}
-
-function convertMetaProperty(node) {
-  if(node.meta === "new" && node.property === "target") {
-    return new Shift.NewTargetExpression();
-  }
-  return null;
-}
-
-function convertObjectPattern(node) {
-  return new Shift.ObjectBinding({ properties: node.properties.map(toBinding)});
-}
-
-function convertAssignmentPattern(node) {
-  return new Shift.BindingWithDefault({
-    binding: toBinding(node.left),
-    init: convert(node.right)
-  });
-}
-
-function convertClassDeclaration(node) {
-  return new Shift.ClassDeclaration({
-    name: toBinding(node.id),
-    super: toExpression(node.superClass),
-    elements: convert(node.body)
-  });
-}
-
-function convertClassExpression(node) {
-  let {name,super:spr,elements} = convertClassDeclaration(node);
-  return new Shift.ClassExpression({ name, super:spr, elements });
-}
-
-function convertClassBody(node) {
-  return node.body.map(convert);
-}
-
-function convertRestElement(node) {
-  return toBinding(node.argument);
-}
-
-function convertElements(elts) {
-  let count = elts.length;
-  if(count === 0) {
-    return [[], null];
-  } else if(elts[count-1].type === "RestElement") {
-    return [elts.slice(0,count-1).map(toBinding), toBinding(elts[count-1])];
-  } else {
-    return [elts.map(toBinding), null];
-  }
-}
-
-function convertArrayPattern(node) {
-  let [elements, restElement] = convertElements(node.elements);
-  return new Shift.ArrayBinding({ elements, restElement });
-}
-
-function convertArrowFunctionExpression(node) {
-  return new Shift.ArrowExpression({
-    params: new Shift.FormalParameters(convertFunctionParams(node)),
-    body: node.expression ? convert(node.body) : convertStatementsToFunctionBody(node.body.body)
-  });
-}
-
-function convertFunctionParams(node) {
-  let [items, rest] = convertElements(node.params);
-  if(node.defaults.length > 0) {
-    items = items.map((v,i) => {
-      let d = node.defaults[i];
-      if(d != null) {
-        return new Shift.BindingWithDefault({ binding: v, init: convert(d) });
-      }
-      return v;
+  },
+  convertElements(elts) {
+    let count = elts.length;
+    if (count === 0) {
+      return [[], null];
+    } else if (elts[count - 1].type === "RestElement") {
+      return [elts.slice(0, count - 1).map(this.toBinding.bind(this)), this.toBinding(elts[count - 1])];
+    } else {
+      return [elts.map(this.toBinding.bind(this)), null];
+    }
+  },
+  convertFunctionParams(node) {
+    let [items, rest] = this.convertElements(node.params);
+    if (node.defaults.length > 0) {
+      items = items.map((v, i) => {
+        let d = node.defaults[i];
+        if (d != null) {
+          return new Shift.BindingWithDefault({ binding: v, init: this.convert(d) });
+        }
+        return v;
+      });
+    }
+    return { items, rest };
+  },
+  toImportNamespace(node, hasDefaultSpecifier) {
+    let firstBinding = this.toBinding(node.specifiers[0]);
+    return new Shift.ImportNamespace({
+      moduleSpecifier: node.source.value,
+      namespaceBinding: hasDefaultSpecifier ? this.toBinding(node.specifiers[1]) : firstBinding,
+      defaultBinding: hasDefaultSpecifier ? firstBinding : null
     });
   }
-  return { items, rest };
-}
-
-function convertMethodDefinition(node) {
-  return new Shift.ClassElement({ isStatic: node.static, method: toMethod(node) });
-}
-
-function convertSuper(node) {
-  return new Shift.Super();
-}
-
-function convertTaggedTemplateExpression(node) {
-  let elts = [];
-  node.quasi.quasis.forEach((e,i) => {
-    elts.push(convertTemplateElement(e));
-    if(i < node.quasi.expressions.length) elts.push(toExpression(node.quasi.expressions[i]));
-  });
-  return new Shift.TemplateExpression({
-    tag: toExpression(node.tag),
-    elements: elts
-  });
-}
-
-function convertTemplateElement(node) {
-  return new Shift.TemplateElement({ rawValue: node.value.raw });
-}
-
-function convertTemplateLiteral(node, tag) {
-  let elts = [];
-  node.quasis.forEach((e,i) => {
-    elts.push(convertTemplateElement(e));
-    if(i < node.expressions.length) elts.push(toExpression(node.expressions[i]));
-  });
-  return new Shift.TemplateExpression({
-    tag: tag != null ? convert(tag) : null,
-    elements: elts
-  });
-}
-
-function convertYieldExpression(node) {
-  if(node.delegate) return new Shift.YieldGeneratorExpression({ expression: toExpression(node.argument) });
-  return new Shift.YieldExpression({ expression: toExpression(node.argument) });
-}
-
-function convertExportAllDeclaration(node) {
-  return new Shift.ExportAllFrom({ moduleSpecifier: node.source.value });
-}
-
-function convertExportNamedDeclaration(node) {
-  if(node.declaration != null) {
-    return new Shift.Export({
-      kind: node.kind,
-      declaration: (node.declaration.type === "VariableDeclaration") ?
-        convertVariableDeclaration(node.declaration, true) :
-        convert(node.declaration)
-    });
-  }
-
-  return new Shift.ExportFrom({
-    moduleSpecifier: node.source != null ? node.source.value : null,
-    namedExports: node.specifiers.map(convert)
-  });
-}
-
-function convertExportSpecifier(node) {
-  return new Shift.ExportSpecifier({
-    exportedName: node.exported.name,
-    name: node.local.name !== node.exported.name ? node.local.name : null
-  });
-}
-
-function convertExportDefaultDeclaration(node) {
-  return new Shift.ExportDefault({ body: convert(node.declaration) });
-}
-
-function toImportNamespace(node, hasDefaultSpecifier) {
-  let firstBinding = toBinding(node.specifiers[0]);
-  return new Shift.ImportNamespace({
-    moduleSpecifier: node.source.value,
-    namespaceBinding: hasDefaultSpecifier ? toBinding(node.specifiers[1]) : firstBinding,
-    defaultBinding: hasDefaultSpecifier ? firstBinding : null
-  });
-}
-
-function convertImportDeclaration(node) {
-  let hasDefaultSpecifier = node.specifiers.some(s => s.type === "ImportDefaultSpecifier");
-  if(node.specifiers.some(s => s.type === "ImportNamespaceSpecifier"))
-    return toImportNamespace(node, hasDefaultSpecifier);
-
-  let namedImports = node.specifiers.map(convert);
-  if(hasDefaultSpecifier) namedImports.shift();
-  return new Shift.Import({
-    moduleSpecifier: node.source.value,
-    namedImports,
-    defaultBinding: hasDefaultSpecifier ? toBinding(node.specifiers[0]) : null
-  });
-}
-
-function convertImportDefaultSpecifier(node) {
-  return toBinding(node.local);
-}
-
-function convertImportNamespaceSpecifier(node) {
-  return toBinding(node.local);
-}
-
-function convertImportSpecifier(node) {
-  return new Shift.ImportSpecifier({ name: node.imported.name, binding: toBinding(node.local) });
-}
-
-function convertSpreadElement(node) {
-  return new Shift.SpreadElement({ expression: toExpression(node.argument)});
-}
-
-const Convert = {
-  AssignmentExpression: convertAssignmentExpression,
-  AssignmentPattern: convertAssignmentPattern,
-  ArrayExpression: convertArrayExpression,
-  ArrayPattern: convertArrayPattern,
-  ArrowFunctionExpression: convertArrowFunctionExpression,
-  BlockStatement: convertBlockStatement,
-  BinaryExpression: convertBinaryExpression,
-  BreakStatement: convertBreakStatement,
-  CallExpression: convertCallExpression,
-  CatchClause: convertCatchClause,
-  ClassDeclaration: convertClassDeclaration,
-  ClassExpression: convertClassExpression,
-  ClassBody: convertClassBody,
-  ConditionalExpression: convertConditionalExpression,
-  ContinueStatement: convertContinueStatement,
-  DoWhileStatement: convertDoWhileStatement,
-  DebuggerStatement: convertDebuggerStatement,
-  EmptyStatement: convertEmptyStatement,
-  ExportAllDeclaration: convertExportAllDeclaration,
-  ExportDefaultDeclaration: convertExportDefaultDeclaration,
-  ExportNamedDeclaration: convertExportNamedDeclaration,
-  ExportSpecifier: convertExportSpecifier,
-  ExpressionStatement: convertExpressionStatement,
-  ForStatement: convertForStatement,
-  ForOfStatement: convertForOfStatement,
-  ForInStatement: convertForInStatement,
-  FunctionDeclaration: convertFunctionDeclaration,
-  FunctionExpression: convertFunctionExpression,
-  IfStatement: convertIfStatement,
-  ImportDeclaration: convertImportDeclaration,
-  ImportDefaultSpecifier: convertImportDefaultSpecifier,
-  ImportNamespaceSpecifier: convertImportNamespaceSpecifier,
-  ImportSpecifier: convertImportSpecifier,
-  Literal: convertLiteral,
-  LabeledStatement: convertLabeledStatement,
-  LogicalExpression: convertBinaryExpression,
-  MemberExpression: convertMemberExpression,
-  MetaProperty: convertMetaProperty,
-  MethodDefinition: convertMethodDefinition,
-  NewExpression: convertNewExpression,
-  ObjectExpression: convertObjectExpression,
-  ObjectPattern: convertObjectPattern,
-  Program: convertProgram,
-  Property: convertProperty,
-  RestElement: convertRestElement,
-  ReturnStatement: convertReturnStatement,
-  SequenceExpression: convertSequenceExpression,
-  SpreadElement: convertSpreadElement,
-  Super: convertSuper,
-  SwitchCase: convertSwitchCase,
-  SwitchStatement: convertSwitchStatement,
-  TaggedTemplateExpression: convertTaggedTemplateExpression,
-  TemplateElement: convertTemplateElement,
-  TemplateLiteral: convertTemplateLiteral,
-  ThisExpression: convertThisExpression,
-  ThrowStatement: convertThrowStatement,
-  TryStatement: convertTryStatement,
-  UnaryExpression: convertUnaryExpression,
-  UpdateExpression: convertUpdateExpression,
-  VariableDeclaration: convertVariableDeclaration,
-  VariableDeclarator: convertVariableDeclarator,
-  WhileStatement: convertWhileStatement,
-  WithStatement: convertWithStatement,
-  YieldExpression: convertYieldExpression
 };
 
+export default ShiftConverter;

--- a/src/to-shift.js
+++ b/src/to-shift.js
@@ -19,6 +19,12 @@ import * as Shift from "shift-ast";
 // convert SpiderMonkey AST format to Shift AST format
 
 const ShiftConverter = {
+  convert(node) {
+    if (node == null) {
+      return null;
+    }
+    return this[`convert${node.type}`](node);
+  },
   convertAssignmentExpression(node) {
     let binding = this.toBinding(node.left),
       expression = this.toExpression(node.right),
@@ -436,12 +442,6 @@ const ShiftConverter = {
   },
 
   // auxiliary methods
-  convert(node) {
-    if (node == null) {
-      return null;
-    }
-    return this[`convert${node.type}`](node);
-  },
   toBinding(node) {
     if (node == null) return null;
     switch (node.type) {

--- a/src/to-spidermonkey.js
+++ b/src/to-spidermonkey.js
@@ -17,6 +17,12 @@
 // convert Shift AST format to SpiderMonkey AST format
 
 const SpiderMonkeyConverter = {
+  convert(ast) {
+    if (ast == null) {
+      return null;
+    }
+    return this[`convert${ast.type}`](ast);
+  },
   // bindings
   convertBindingWithDefault(node) {
     return {
@@ -801,12 +807,6 @@ const SpiderMonkeyConverter = {
   },
 
   // auxiliary methods
-  convert(ast) {
-    if (ast == null) {
-      return null;
-    }
-    return this[`convert${ast.type}`](ast);
-  },
   convertPropertyName(node) {
     switch (node.type) {
       case "StaticPropertyName":

--- a/test/simple.js
+++ b/test/simple.js
@@ -56,6 +56,7 @@ suite("simple", function () {
     roundTrip("LiteralStringExpression", `let x = 'x';`);
     roundTrip("LiteralStringExpression", `let x = "x";`);
     roundTrip("LiteralNumericExpression", `0;`);
+    roundTrip("LiteralInfinityExpression", `2e308`);
     roundTrip("LiteralNullExpression", `null;`);
     roundTrip("LiteralRegExpExpression", `/a/g;`);
     roundTrip("BinaryExpression", `1+2;`);


### PR DESCRIPTION
This PR is related to https://github.com/shapesecurity/shift-spidermonkey-converter-js/issues/16.

To better support conversion to/from forks of ESTree (currently targeting Babel) I've modified the implementation to allow for class-based extensibility.

There's a method `createChild` and a function `childConverter` that don't smell right. The former is used to create an instance of a subclass in non-overridden methods. The later is a utility that provides a mapper function for converting collections. Any suggestions on alternatives are welcome.
